### PR TITLE
Philips URMT26RST004 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Linux daemon that captures voice audio from BLE TV remotes using the [Android TV
 | Device | Status |
 |--------|--------|
 | G20S Pro / G20S Pro Plus / G20BTS Plus | Verified working |
+| Philips URMT26RST004 (TV Voice RC_5) | Verified working |
 | Other ATVV-compatible remotes | Unknown |
 
 If you have a remote you'd like to test, open an issue with the device name, Bluetooth address, and output of `atvvoice -d <ADDR> -vv`. See [docs/research/report.md](docs/research/report.md) for protocol details.

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use bluer::{gatt::remote::Characteristic, Adapter, AdapterEvent, Address, Device, Uuid};
+use bluer::{gatt::{remote::Characteristic, WriteOp}, Adapter, AdapterEvent, Address, Device, Uuid};
 use futures::{Stream, StreamExt};
 
 use crate::atvv::{BleDevice, BleFut, BleStream, DeviceConnectionEvent};
@@ -74,7 +74,14 @@ impl BleDevice for BluerDevice<'_> {
     fn write_command(&self, data: &[u8]) -> BleFut<'_, ()> {
         let data = data.to_vec();
         Box::pin(async move {
-            self.chars.tx.write(&data).await?;
+            // TX characteristic has the 'write' flag (not 'write-without-response'),
+            // so we must use ATT Write Request (WriteOp::Request) instead of the
+            // default WriteOp::Command (ATT Write Command). Remotes silently ignore
+            // Write Commands on characteristics that only support Write Request.
+            self.chars.tx.write_ext(&data, &bluer::gatt::remote::CharacteristicWriteRequest {
+                op_type: WriteOp::Request,
+                ..Default::default()
+            }).await?;
             Ok(())
         })
     }
@@ -223,7 +230,7 @@ pub async fn resolve_chars(device: &Device) -> Result<AtvvChars> {
 /// and responds to GET_CAPS commands.
 ///
 /// Returns `Ok(true)` if the handshake was performed, `Ok(false)` if not a Philips device.
-pub async fn vendor_handshake(device: &Device) -> Result<bool> {
+pub async fn vendor_handshake(device: &Device) -> Result<Option<crate::atvv::BleStream<Vec<u8>>>> {
     let mut ff01_char = None;
     let mut ff02_char = None;
 
@@ -245,18 +252,20 @@ pub async fn vendor_handshake(device: &Device) -> Result<bool> {
 
     let ff01 = match ff01_char {
         Some(c) => c,
-        None => return Ok(false), // Not a Philips device
+        None => return Ok(None), // Not a Philips device
     };
 
     tracing::info!("Detected Philips vendor service. Performing vendor handshake...");
 
     // Step 1: Subscribe to ff02 (required before remote accepts ff01 write).
     // The remote sends "ntf_enable" on ff02 as a greeting when subscribed.
-    let _ff02_stream = if let Some(ff02) = ff02_char {
+    // We return this stream to the caller so it stays subscribed for the session —
+    // dropping it (StopNotify) resets the remote's ATVV-ready state.
+    let ff02_stream: Option<crate::atvv::BleStream<Vec<u8>>> = if let Some(ff02) = ff02_char {
         match ff02.notify().await {
             Ok(stream) => {
                 tracing::debug!("Subscribed to vendor ff02 notifications");
-                Some(stream)
+                Some(Box::pin(stream))
             }
             Err(e) => {
                 tracing::warn!("Vendor ff02 StartNotify failed (continuing): {e}");
@@ -269,14 +278,17 @@ pub async fn vendor_handshake(device: &Device) -> Result<bool> {
     };
 
     // Step 2: Write "ntf_enable" to ff01 to signal readiness.
-    ff01.write(b"ntf_enable").await
-        .context("Philips vendor handshake: write to ff01 failed")?;
+    ff01.write_ext(b"ntf_enable", &bluer::gatt::remote::CharacteristicWriteRequest {
+        op_type: WriteOp::Request,
+        ..Default::default()
+    }).await.context("Philips vendor handshake: write to ff01 failed")?;
     tracing::debug!("Vendor handshake: wrote ntf_enable to ff01");
 
     // Step 3: Wait for remote to process and enter ATVV-ready state.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     tracing::info!("Vendor handshake complete");
-    // _ff02_stream dropped here → StopNotify called automatically
-    Ok(true)
+    // Return the ff02 stream so the caller can hold it alive for the session.
+    // Dropping it would call StopNotify and reset the remote's ATVV-ready state.
+    Ok(ff02_stream)
 }

--- a/src/ble.rs
+++ b/src/ble.rs
@@ -1,6 +1,7 @@
 //! BLE device discovery and ATVV GATT characteristic resolution.
 
 use std::pin::Pin;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use bluer::{gatt::remote::Characteristic, Adapter, AdapterEvent, Address, Device, Uuid};
@@ -34,6 +35,15 @@ pub const ATVV_CHAR_RX: Uuid = Uuid::from_u128(0xab5e0003_5a21_4f05_bc7d_af01f61
 
 /// ATVV CTL Characteristic (Remote → Host, control): AB5E0004
 pub const ATVV_CHAR_CTL: Uuid = Uuid::from_u128(0xab5e0004_5a21_4f05_bc7d_af01f617b664);
+
+/// Philips vendor write characteristic UUID (ff01) — vendor activation channel.
+/// Writing "ntf_enable" here signals the remote to enter ATVV-ready mode.
+/// Full UUID as observed on device: 02f00000-0000-0000-0000-00000000ff01
+const PHILIPS_VENDOR_FF01: Uuid = Uuid::from_u128(0x02f00000_0000_0000_0000_00000000ff01);
+
+/// Philips vendor notify characteristic UUID (ff02) — must be subscribed before writing ff01.
+/// Full UUID as observed on device: 02f00000-0000-0000-0000-00000000ff02
+const PHILIPS_VENDOR_FF02: Uuid = Uuid::from_u128(0x02f00000_0000_0000_0000_00000000ff02);
 
 /// Resolved ATVV characteristics for a connected device.
 pub struct AtvvChars {
@@ -197,4 +207,76 @@ pub async fn resolve_chars(device: &Device) -> Result<AtvvChars> {
         rx: rx.context("ATVV RX characteristic not found")?,
         ctl: ctl.context("ATVV CTL characteristic not found")?,
     })
+}
+
+/// Attempt Philips vendor handshake if the device requires it.
+///
+/// Some Philips TV Voice remotes (e.g. URMT26RST004) require a proprietary
+/// vendor handshake before they will respond to ATVV protocol commands.
+///
+/// The handshake sequence (reverse-engineered from device traffic):
+///  1. Subscribe to ff02 notifications (remote sends "ntf_enable" as a greeting)
+///  2. Write "ntf_enable" to ff01 (signals readiness to the remote)
+///  3. Wait ~500ms for remote to enter ATVV-ready state
+///
+/// After this sequence, the remote accepts ATT subscriptions on ATVV characteristics
+/// and responds to GET_CAPS commands.
+///
+/// Returns `Ok(true)` if the handshake was performed, `Ok(false)` if not a Philips device.
+pub async fn vendor_handshake(device: &Device) -> Result<bool> {
+    let mut ff01_char = None;
+    let mut ff02_char = None;
+
+    for service in device.services().await? {
+        if service.uuid().await? == ATVV_SERVICE {
+            continue;
+        }
+        for char in service.characteristics().await? {
+            match char.uuid().await? {
+                uuid if uuid == PHILIPS_VENDOR_FF01 => ff01_char = Some(char),
+                uuid if uuid == PHILIPS_VENDOR_FF02 => ff02_char = Some(char),
+                _ => {}
+            }
+        }
+        if ff01_char.is_some() {
+            break;
+        }
+    }
+
+    let ff01 = match ff01_char {
+        Some(c) => c,
+        None => return Ok(false), // Not a Philips device
+    };
+
+    tracing::info!("Detected Philips vendor service. Performing vendor handshake...");
+
+    // Step 1: Subscribe to ff02 (required before remote accepts ff01 write).
+    // The remote sends "ntf_enable" on ff02 as a greeting when subscribed.
+    let _ff02_stream = if let Some(ff02) = ff02_char {
+        match ff02.notify().await {
+            Ok(stream) => {
+                tracing::debug!("Subscribed to vendor ff02 notifications");
+                Some(stream)
+            }
+            Err(e) => {
+                tracing::warn!("Vendor ff02 StartNotify failed (continuing): {e}");
+                None
+            }
+        }
+    } else {
+        tracing::warn!("Vendor ff02 not found; handshake may be incomplete");
+        None
+    };
+
+    // Step 2: Write "ntf_enable" to ff01 to signal readiness.
+    ff01.write(b"ntf_enable").await
+        .context("Philips vendor handshake: write to ff01 failed")?;
+    tracing::debug!("Vendor handshake: wrote ntf_enable to ff01");
+
+    // Step 3: Wait for remote to process and enter ATVV-ready state.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    tracing::info!("Vendor handshake complete");
+    // _ff02_stream dropped here → StopNotify called automatically
+    Ok(true)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,6 +280,11 @@ async fn main() -> anyhow::Result<()> {
             }
         };
 
+        // Perform vendor handshake if the device requires one (e.g. Philips TV Voice remotes).
+        if let Err(e) = ble::vendor_handshake(&device).await {
+            tracing::warn!("Vendor handshake failed: {e}");
+        }
+
         // Derive instance names from device.
         let ble_name = device.name().await.ok().flatten().unwrap_or_default();
         let suffix = cli.name.clone().unwrap_or_else(|| {
@@ -507,12 +512,18 @@ async fn main() -> anyhow::Result<()> {
             }
 
             // Re-resolve characteristics (handles may change after reconnect)
+            // Also re-run vendor handshake since some devices (e.g. Philips) reset their
+            // ATVV-ready state on reconnect.
             chars = loop {
                 tokio::select! {
                     result = ble::resolve_chars(&device) => {
                         match result {
                             Ok(c) => {
                                 tracing::info!("ATVV characteristics re-resolved");
+                                // Re-run vendor handshake (e.g. Philips remotes reset state on reconnect)
+                                if let Err(e) = ble::vendor_handshake(&device).await {
+                                    tracing::warn!("Vendor handshake failed after reconnect: {e}");
+                                }
                                 break c;
                             }
                             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,9 +281,15 @@ async fn main() -> anyhow::Result<()> {
         };
 
         // Perform vendor handshake if the device requires one (e.g. Philips TV Voice remotes).
-        if let Err(e) = ble::vendor_handshake(&device).await {
-            tracing::warn!("Vendor handshake failed: {e}");
-        }
+        // Keep the returned stream alive: dropping it calls StopNotify on ff02,
+        // which resets the remote's ATVV-ready state before GET_CAPS can succeed.
+        let mut _vendor_ff02_stream = match ble::vendor_handshake(&device).await {
+            Ok(stream) => stream,
+            Err(e) => {
+                tracing::warn!("Vendor handshake failed: {e}");
+                None
+            }
+        };
 
         // Derive instance names from device.
         let ble_name = device.name().await.ok().flatten().unwrap_or_default();
@@ -521,9 +527,13 @@ async fn main() -> anyhow::Result<()> {
                             Ok(c) => {
                                 tracing::info!("ATVV characteristics re-resolved");
                                 // Re-run vendor handshake (e.g. Philips remotes reset state on reconnect)
-                                if let Err(e) = ble::vendor_handshake(&device).await {
-                                    tracing::warn!("Vendor handshake failed after reconnect: {e}");
-                                }
+                                _vendor_ff02_stream = match ble::vendor_handshake(&device).await {
+                                    Ok(stream) => stream,
+                                    Err(e) => {
+                                        tracing::warn!("Vendor handshake failed after reconnect: {e}");
+                                        None
+                                    }
+                                };
                                 break c;
                             }
                             Err(e) => {


### PR DESCRIPTION
Added support to ATVVoice to work with Philips Android TV voice remotes.

Tested model: URMT26RST004

But likely the broader URMT2x family will work.

These remotes implement the ATVV BLE protocol, but require a proprietary vendor handshake before the ATVV service becomes operational.

The Philips URMT26RST004 was tested and confirmed working with full 16 kHz audio capture, delivering clear speech recognition suitable for voice assistant use.